### PR TITLE
feat: add sitemap and robots metadata routes

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import { type MetadataRoute } from "next"
+
+import { siteConfig } from "@/lib/site/config"
+
+export const dynamic = "force-static"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/api/",
+    },
+    sitemap: new URL("/sitemap.xml", siteConfig.siteUrl).href,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,44 @@
+import { type MetadataRoute } from "next"
+
+import { authors, newsConfig, peopleConfig, postMetas, userpages } from "@/lib/content"
+import { siteConfig } from "@/lib/site/config"
+
+type SitemapEntry = MetadataRoute.Sitemap[number]
+
+export const dynamic = "force-static"
+
+function createSitemapEntry(pathname: `/${string}`, lastModified?: string): SitemapEntry {
+  const url = new URL(pathname, siteConfig.siteUrl).href
+
+  return lastModified ? { url, lastModified } : { url }
+}
+
+function isIndexable(content: { draft?: boolean; seo: { noIndex: boolean } }): boolean {
+  return !content.draft && !content.seo.noIndex
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [
+    createSitemapEntry("/"),
+    createSitemapEntry("/posts"),
+    createSitemapEntry("/posts/tags"),
+
+    ...postMetas
+      .filter(isIndexable)
+      .map((post) => createSitemapEntry(`/post/${post.slug}`, post.dateUpdate)),
+
+    ...userpages.filter(isIndexable).map((userpage) => createSitemapEntry(`/${userpage.slug}`)),
+
+    ...authors.filter(isIndexable).map((author) => createSitemapEntry(`/author/${author.slug}`)),
+  ]
+
+  if (newsConfig && isIndexable(newsConfig)) {
+    entries.push(createSitemapEntry("/news"))
+  }
+
+  if (peopleConfig && isIndexable(peopleConfig)) {
+    entries.push(createSitemapEntry("/people"))
+  }
+
+  return entries
+}


### PR DESCRIPTION
## Summary

- generate a static sitemap from the active site's posts, user pages, authors, and optional News/People pages
- exclude drafts, `seo.noIndex` content, taxonomy and author archive pages, and paginated routes
- add a static `robots.txt` that advertises the site-specific sitemap and disallows `/api/`

## Testing

- `bun check`
- `bun run build`
- `SITE_DIR=sites/blog bun run build`
- `SITE_DIR=sites/blog bun check`