### PR TITLE
fix: validate userpage routes and improve site CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,10 +2,40 @@ name: Code quality
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  discover-sites:
+    name: Discover sites
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      directories: ${{ steps.directories.outputs.value }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Discover site directories
+        id: directories
+        shell: bash
+        run: |
+          directories="$(find sites -mindepth 1 -maxdepth 1 -type d -print | sort | jq -Rsc 'split("\n") | map(select(length > 0))')"
+
+          if [[ "${directories}" == "[]" ]]; then
+            echo "::error::No site directories found under sites/"
+            exit 1
+          fi
+
+          echo "value=${directories}" >> "${GITHUB_OUTPUT}"
+
   quality:
+    name: Lint and format
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,7 +48,39 @@ jobs:
           node-version: 26
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
-      - run: bun run build
-      - run: bun run lint --format=github
-      - run: bun run format
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Generate types
+        run: |
+          bun run prebuild
+          bunx next typegen
+      - name: Lint
+        run: bun run lint --format=github
+      - name: Check formatting
+        run: bun run format
+
+  build:
+    name: Build (${{ matrix.site-directory }})
+    needs: discover-sites
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        site-directory: ${{ fromJSON(needs.discover-sites.outputs.directories) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build site
+        run: bun run build
+        env:
+          SITE_DIR: ${{ matrix.site-directory }}

--- a/src/content-collections/collections/pages.ts
+++ b/src/content-collections/collections/pages.ts
@@ -7,15 +7,39 @@ import {
   mdxTransform,
 } from "@/content-collections/collections/basic"
 
+const RESERVED_USERPAGE_ROOT_SEGMENTS = new Set([
+  "api",
+  "author",
+  "news",
+  "people",
+  "post",
+  "posts",
+])
+
 export const userpageContentSchema = mdxContentSchema.extend({
   draft: z.boolean().default(false),
 })
+
+function assertAvailableUserpageSlug(slug: string, filePath: string): void {
+  const rootSegment = slug.split("/").at(0)
+
+  if (!rootSegment || !RESERVED_USERPAGE_ROOT_SEGMENTS.has(rootSegment)) {
+    return
+  }
+
+  throw new Error(
+    `Userpage "${filePath}" resolves to reserved route "/${slug}". ` +
+      `The top-level segment "/${rootSegment}" is owned by the application.`
+  )
+}
 
 export async function userpageTransform(
   file: { _meta: Meta } & z.infer<typeof userpageContentSchema>,
   ctx: CollectionContext
 ) {
   const basicTransformed = await basicTransform(file)
+  assertAvailableUserpageSlug(basicTransformed.slug, file._meta.filePath)
+
   const mdxTransformed = await mdxTransform(file, ctx)
 
   return {


### PR DESCRIPTION
## Summary

- reject userpages whose top-level slug conflicts with application-owned routes
- run Code quality for pull requests and pushes to `main`, and cancel superseded runs
- discover every first-level directory under `sites/` and build each site through a dynamic matrix
- run type generation, lint, and formatting once instead of repeating quality checks per site

## Validation

- ran `bun check` before each commit
- verified a temporary `sites/demo/_pages/posts.mdx` fails with the reserved `/posts` route error
- dynamically discovered and successfully built `sites/blog` and `sites/demo`
- ran a final `bun check` and `git diff --check`