### PR TITLE
feat: add JSON-LD to core pages

### DIFF
--- a/src/app/author/[author]/page.tsx
+++ b/src/app/author/[author]/page.tsx
@@ -6,7 +6,9 @@ import { MdxProse } from "@/components/mdx/mdx-prose"
 import { AuthorProfile } from "@/components/pages/author/author-profile"
 import { AuthorRecentArticles } from "@/components/pages/author/author-recent-articles"
 import { PageShell } from "@/components/pages/basic/page-shell"
+import { JsonLd } from "@/components/seo/json-ld"
 import { authors, getAuthorBySlug, getPostMetasByAuthorSlug } from "@/lib/content"
+import { buildAuthorJsonLd } from "@/lib/site/json-ld"
 import { buildPageMetadata } from "@/lib/site/metadata"
 import { cn } from "@/lib/utils"
 
@@ -47,6 +49,8 @@ export default async function AuthorPage(props: PageProps<"/author/[author]">) {
 
   return (
     <PageShell.Root>
+      {!author.seo.noIndex && <JsonLd data={buildAuthorJsonLd(author)} />}
+
       <PageShell.Body
         className={cn(
           "grid gap-10",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,12 +7,16 @@ import { HomeSectionArticles } from "@/components/home/home-section-articles"
 import { HomeSectionNews } from "@/components/home/home-section-news"
 import { HomeSectionResearch } from "@/components/home/home-section-research"
 import { PageShell } from "@/components/pages/basic/page-shell"
+import { JsonLd } from "@/components/seo/json-ld"
 import { getPostMetaBySlug, newsConfig, postMetas } from "@/lib/content"
 import { siteConfig } from "@/lib/site/config"
+import { buildWebsiteJsonLd } from "@/lib/site/json-ld"
 
 export default function HomePage() {
   return (
     <PageShell.Root className="max-w-5xl gap-20 lg:gap-20">
+      <JsonLd data={buildWebsiteJsonLd()} />
+
       <HomeHero
         greeting={homeConfig.hero.greeting}
         name={homeConfig.hero.name ?? siteConfig.author}

--- a/src/app/post/[...slug]/page.tsx
+++ b/src/app/post/[...slug]/page.tsx
@@ -7,6 +7,7 @@ import { MdxProse } from "@/components/mdx/mdx-prose"
 import { PageShell } from "@/components/pages/basic/page-shell"
 import { PostHeader } from "@/components/pages/post/post-header"
 import { hasPostTocItems, PostToc } from "@/components/pages/post/post-toc"
+import { JsonLd } from "@/components/seo/json-ld"
 import { AutoLink, TwemojifyText } from "@/components/ui/my"
 import {
   Breadcrumb,
@@ -18,6 +19,7 @@ import {
 } from "@/components/ui/shadcn/breadcrumb"
 import { getPostBySlug, getPostMetaBySlug, postMetas } from "@/lib/content"
 import { siteConfig } from "@/lib/site/config"
+import { buildPostJsonLd } from "@/lib/site/json-ld"
 import { buildRobotsMetadata } from "@/lib/site/metadata"
 
 export async function generateStaticParams(): Promise<{ slug: string[] }[]> {
@@ -79,6 +81,8 @@ export default async function PostPage(props: PageProps<"/post/[...slug]">) {
 
   return (
     <PageShell.Root as="article">
+      {!post.seo.noIndex && <JsonLd data={buildPostJsonLd(post)} />}
+
       <PageShell.Top>
         <Breadcrumb>
           <BreadcrumbList>

--- a/src/components/seo/json-ld.tsx
+++ b/src/components/seo/json-ld.tsx
@@ -1,0 +1,14 @@
+type JsonLdProps = {
+  data: Record<string, unknown>
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replaceAll("<", "\\u003c"),
+      }}
+    />
+  )
+}

--- a/src/lib/site/json-ld.ts
+++ b/src/lib/site/json-ld.ts
@@ -1,4 +1,5 @@
 import { type AuthorMeta, type PostMeta } from "@/lib/content"
+import { classifyHref } from "@/lib/href"
 import { siteConfig } from "@/lib/site/config"
 
 const schemaContext = "https://schema.org"
@@ -16,17 +17,17 @@ function webUrl(href: string | undefined): string | undefined {
     return undefined
   }
 
-  const url = new URL(href, siteConfig.siteUrl)
-  return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : undefined
+  const kind = classifyHref(href)
+
+  if (kind === "internal") {
+    return absoluteUrl(href)
+  }
+
+  return kind === "external" ? href : undefined
 }
 
 function externalWebUrl(href: string): string | undefined {
-  try {
-    const url = new URL(href)
-    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : undefined
-  } catch {
-    return undefined
-  }
+  return classifyHref(href) === "external" ? href : undefined
 }
 
 function buildPostAuthor(author: PostMeta["authors"][number]) {

--- a/src/lib/site/json-ld.ts
+++ b/src/lib/site/json-ld.ts
@@ -1,0 +1,153 @@
+import { type AuthorMeta, type PostMeta } from "@/lib/content"
+import { siteConfig } from "@/lib/site/config"
+
+const schemaContext = "https://schema.org"
+
+function absoluteUrl(pathname: string): string {
+  return new URL(pathname, siteConfig.siteUrl).toString()
+}
+
+function websiteId(): string {
+  return `${absoluteUrl("/")}#website`
+}
+
+function webUrl(href: string | undefined): string | undefined {
+  if (!href) {
+    return undefined
+  }
+
+  const url = new URL(href, siteConfig.siteUrl)
+  return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : undefined
+}
+
+function externalWebUrl(href: string): string | undefined {
+  try {
+    const url = new URL(href)
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function buildPostAuthor(author: PostMeta["authors"][number]) {
+  if (author.kind === "internal") {
+    const authorUrl = absoluteUrl(`/author/${author.slug}`)
+
+    return {
+      "@type": "Person",
+      "@id": `${authorUrl}#person`,
+      name: author.name,
+      url: authorUrl,
+    }
+  }
+
+  return {
+    "@type": "Person",
+    name: author.name,
+    url: webUrl(author.href),
+  }
+}
+
+export function buildWebsiteJsonLd() {
+  const url = absoluteUrl("/")
+
+  return {
+    "@context": schemaContext,
+    "@type": "WebSite",
+    "@id": websiteId(),
+    url,
+    name: siteConfig.siteTitle,
+    description: siteConfig.description,
+    inLanguage: siteConfig.locale,
+  }
+}
+
+export function buildPostJsonLd(post: PostMeta) {
+  const pageUrl = absoluteUrl(`/post/${post.slug}`)
+
+  const article = {
+    "@type": "BlogPosting",
+    "@id": `${pageUrl}#article`,
+    url: pageUrl,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": pageUrl,
+    },
+    headline: post.title,
+    abstract: post.summary,
+    description: post.seo.description,
+    datePublished: post.datePublish,
+    dateModified: post.dateUpdate,
+    image: post.cover ? absoluteUrl(post.cover) : undefined,
+    author: post.authors.length > 0 ? post.authors.map(buildPostAuthor) : undefined,
+    articleSection: post.category.name,
+    keywords: post.tags.map((tag) => tag.name),
+    inLanguage: siteConfig.locale,
+    isPartOf: { "@id": websiteId() },
+  }
+
+  const breadcrumb = {
+    "@type": "BreadcrumbList",
+    "@id": `${pageUrl}#breadcrumb`,
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Articles",
+        item: absoluteUrl("/posts"),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: post.category.name,
+        item: absoluteUrl(`/posts/by-category/${post.category.slug}`),
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: post.title,
+        item: pageUrl,
+      },
+    ],
+  }
+
+  return {
+    "@context": schemaContext,
+    "@graph": [article, breadcrumb],
+  }
+}
+
+export function buildAuthorJsonLd(author: AuthorMeta) {
+  const pageUrl = absoluteUrl(`/author/${author.slug}`)
+  const personId = `${pageUrl}#person`
+  const sameAs = author.socials.flatMap((social) => {
+    const url = externalWebUrl(social.href)
+    return url ? [url] : []
+  })
+
+  const person = {
+    "@type": "Person",
+    "@id": personId,
+    name: author.name,
+    url: pageUrl,
+    description: author.seo.description,
+    image: author.avatar ? absoluteUrl(author.avatar) : undefined,
+    sameAs: sameAs.length > 0 ? sameAs : undefined,
+  }
+
+  const profilePage = {
+    "@type": "ProfilePage",
+    "@id": `${pageUrl}#profile`,
+    url: pageUrl,
+    name: author.name,
+    description: author.seo.description,
+    inLanguage: siteConfig.locale,
+    isPartOf: { "@id": websiteId() },
+    mainEntity: { "@id": personId },
+  }
+
+  return {
+    "@context": schemaContext,
+    "@graph": [profilePage, person],
+  }
+}


### PR DESCRIPTION
## Summary
- add a small reusable JSON-LD renderer with safe `<` escaping
- emit `WebSite` on the homepage, `BlogPosting + BreadcrumbList` on posts, and `ProfilePage + Person` on author pages
- omit structured data for `noIndex` post and author content
- keep the scope dependency-free: no `site.config`, frontmatter, taxonomy, pagination, publisher, or search-action changes

## Validation
- ran `bun check` immediately before the commit
- built both `sites/blog` and `sites/demo`
- parsed every emitted JSON-LD script from the static HTML (10 blog documents and 12 demo documents)
- verified URL-like fields are absolute HTTP(S) URLs and `sameAs` contains no `mailto:` values