### PR TITLE
fix: correct cosupervisors demo field

### DIFF
--- a/sites/demo/people.yml
+++ b/sites/demo/people.yml
@@ -55,7 +55,7 @@ alumni:
     - name: Cedric Diggory
       startYear: 2019
       endYear: 2024
-      coSupervisors:
+      cosupervisors:
         - name: Prof. Minerva McGonagall
           href: https://example.com/mcgonagall
       description: Now a lecturer at Example University.


### PR DESCRIPTION
Fix the demo people YAML field name from `coSupervisors` to `cosupervisors` so it matches the schema.