### PR TITLE
feat: polish long-form reading interactions

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,7 @@
 @import "../styles/footnote.css";
 @import "../styles/katex.css";
 @import "../styles/mdx-heading.css";
+@import "../styles/theme-transition.css";
 @import "../styles/twemoji.css";
 
 @custom-variant dark (&:is(.dark *));

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,7 @@
 @import "../styles/code-highlight.css";
 @import "../styles/footnote.css";
 @import "../styles/katex.css";
+@import "../styles/mdx-heading.css";
 @import "../styles/twemoji.css";
 
 @custom-variant dark (&:is(.dark *));

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { type ReactNode } from "react"
 import { ThemeProvider } from "@wrksz/themes/next"
 
 import { Analytics } from "@/components/analytics"
+import { BackToTop } from "@/components/site/back-to-top"
 import { SiteFooter } from "@/components/site/site-footer"
 import { SiteHeader } from "@/components/site/site-header"
 import { TooltipProvider } from "@/components/ui/shadcn/tooltip"
@@ -138,6 +139,7 @@ export default function RootLayout({
               <main className="flex flex-1 flex-col">{children}</main>
               <SiteFooter />
             </div>
+            <BackToTop />
           </TooltipProvider>
         </ThemeProvider>
         <Analytics />

--- a/src/components/mdx/code-block-content.tsx
+++ b/src/components/mdx/code-block-content.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import * as React from "react"
+
+import { IconChevronDown, IconChevronUp } from "@tabler/icons-react"
+
+import { CodeCopyButton } from "@/components/mdx/code-copy-button"
+import { Button } from "@/components/ui/shadcn/button"
+import { cn } from "@/lib/utils"
+
+const COLLAPSED_LINE_COUNT = 10
+
+type CodeBlockContentProps = {
+  title?: string
+  languageName: string
+  code: string
+  lineCount: number
+  children: React.ReactNode
+}
+
+export function CodeBlockContent({
+  title,
+  languageName,
+  code,
+  lineCount,
+  children,
+}: CodeBlockContentProps) {
+  const canCollapse = lineCount > COLLAPSED_LINE_COUNT
+  const [isExpanded, setIsExpanded] = React.useState(!canCollapse)
+  const bodyId = React.useId()
+
+  const toggleLabel = isExpanded
+    ? "Collapse code block"
+    : `Show ${lineCount - COLLAPSED_LINE_COUNT} more ${
+        lineCount - COLLAPSED_LINE_COUNT === 1 ? "line" : "lines"
+      }`
+
+  return (
+    <>
+      <div
+        data-slot="mdx-code-header"
+        className={cn("flex min-h-10 items-center gap-2", "border-b bg-muted/40 px-3")}
+      >
+        <span
+          className={cn("min-w-0 flex-1 truncate", "font-mono text-xs font-medium text-foreground")}
+          title={title}
+        >
+          {title ?? languageName}
+        </span>
+
+        {title && (
+          <span
+            className={cn(
+              "shrink-0 rounded-sm border bg-background/60",
+              "px-1.5 py-0.5 font-mono",
+              "text-[0.625rem] leading-none",
+              "tracking-wide text-muted-foreground uppercase"
+            )}
+          >
+            {languageName}
+          </span>
+        )}
+
+        {canCollapse && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            aria-controls={bodyId}
+            aria-expanded={isExpanded}
+            aria-label={toggleLabel}
+            title={toggleLabel}
+            onClick={() => setIsExpanded((expanded) => !expanded)}
+            className="shrink-0 text-muted-foreground hover:text-foreground print:hidden"
+          >
+            {isExpanded ? <IconChevronUp aria-hidden /> : <IconChevronDown aria-hidden />}
+            <span className="hidden sm:inline">{isExpanded ? "Collapse" : "Expand"}</span>
+          </Button>
+        )}
+
+        <CodeCopyButton value={code} />
+      </div>
+
+      <div
+        id={bodyId}
+        data-slot="mdx-code-body"
+        data-collapsed={canCollapse && !isExpanded ? "" : undefined}
+        className={cn(
+          "relative",
+          canCollapse &&
+            !isExpanded &&
+            "max-h-[17rem] overflow-hidden print:max-h-none print:overflow-visible"
+        )}
+      >
+        {children}
+
+        {canCollapse && !isExpanded && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-linear-to-t from-card to-transparent print:hidden"
+          />
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/components/mdx/heading-anchor.tsx
+++ b/src/components/mdx/heading-anchor.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import * as React from "react"
+
+import { IconCheck, IconLink } from "@tabler/icons-react"
+
+import { cn } from "@/lib/utils"
+
+type HeadingAnchorProps = {
+  id: string
+}
+
+export function HeadingAnchor({ id }: HeadingAnchorProps) {
+  const [copied, setCopied] = React.useState(false)
+  const timeoutRef = React.useRef<number | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
+  async function handleClick() {
+    const url = new URL(window.location.href)
+    url.hash = id
+
+    try {
+      await navigator.clipboard.writeText(url.toString())
+      setCopied(true)
+
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current)
+      }
+
+      timeoutRef.current = window.setTimeout(() => {
+        setCopied(false)
+        timeoutRef.current = null
+      }, 2000)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  const label = copied ? "Link copied" : "Copy link to this section"
+
+  return (
+    <a
+      href={`#${id}`}
+      aria-label={label}
+      title={label}
+      data-slot="mdx-heading-anchor"
+      onClick={handleClick}
+      className={cn(
+        "ml-1.5 inline-flex rounded-sm p-1 align-middle",
+        "text-muted-foreground opacity-0 transition-[color,opacity]",
+        "group-hover:opacity-100 hover:text-primary",
+        "focus-visible:opacity-100 focus-visible:outline-none",
+        "focus-visible:ring-2 focus-visible:ring-ring",
+        "focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "[@media(hover:none)]:opacity-60",
+        "motion-reduce:transition-none print:hidden"
+      )}
+    >
+      {copied ? (
+        <IconCheck aria-hidden="true" className="size-[0.8em]" />
+      ) : (
+        <IconLink aria-hidden="true" className="size-[0.8em]" />
+      )}
+    </a>
+  )
+}

--- a/src/components/mdx/mdx-code-highlight.tsx
+++ b/src/components/mdx/mdx-code-highlight.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { CodeCopyButton } from "@/components/mdx/code-copy-button"
+import { CodeBlockContent } from "@/components/mdx/code-block-content"
 import { cn } from "@/lib/utils"
 
 type MdxCodeBlockProps = React.ComponentPropsWithoutRef<"figure"> & {
@@ -121,6 +121,8 @@ export function MdxCodeBlock({
 
   const code = getNodeText(preNode.props.children).replace(/\n$/, "")
 
+  const lineCount = code.split("\n").length
+
   const highlightedPre = React.cloneElement(preNode, {
     "data-slot": "mdx-code-pre",
     className: cn(
@@ -137,34 +139,9 @@ export function MdxCodeBlock({
       className={cn("overflow-hidden rounded-lg border bg-card shadow-xs", className)}
       {...props}
     >
-      <div
-        data-slot="mdx-code-header"
-        className={cn("flex min-h-10 items-center gap-2", "border-b bg-muted/40 px-3")}
-      >
-        <span
-          className={cn("min-w-0 flex-1 truncate", "font-mono text-xs font-medium text-foreground")}
-          title={title}
-        >
-          {title ?? languageName}
-        </span>
-
-        {title && (
-          <span
-            className={cn(
-              "shrink-0 rounded-sm border bg-background/60",
-              "px-1.5 py-0.5 font-mono",
-              "text-[0.625rem] leading-none",
-              "tracking-wide text-muted-foreground uppercase"
-            )}
-          >
-            {languageName}
-          </span>
-        )}
-
-        <CodeCopyButton value={code} />
-      </div>
-
-      <div data-slot="mdx-code-body">{highlightedPre}</div>
+      <CodeBlockContent title={title} languageName={languageName} code={code} lineCount={lineCount}>
+        {highlightedPre}
+      </CodeBlockContent>
 
       {captionNode && (
         <figcaption

--- a/src/components/mdx/mdx-heading.tsx
+++ b/src/components/mdx/mdx-heading.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 
-import { IconLink } from "@tabler/icons-react"
-
+import { HeadingAnchor } from "@/components/mdx/heading-anchor"
 import { cn } from "@/lib/utils"
 
 type HeadingLevel = "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
@@ -35,24 +34,8 @@ function MdxHeading({ level, id, className, children, ...props }: MdxHeadingProp
       )}
       {...props}
     >
-      {children}
-      {id && (
-        <a
-          href={`#${id}`}
-          aria-label="Link to this section"
-          data-slot="mdx-heading-anchor"
-          className={cn(
-            "ml-2 inline-flex align-middle text-muted-foreground opacity-0 transition-opacity",
-            "group-hover:opacity-100 hover:text-primary",
-            "focus-visible:opacity-100 focus-visible:outline-none",
-            "focus-visible:ring-2 focus-visible:ring-ring",
-            "focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-            "motion-reduce:transition-none print:hidden"
-          )}
-        >
-          <IconLink aria-hidden />
-        </a>
-      )}
+      <span data-slot="mdx-heading-content">{children}</span>
+      {id && <HeadingAnchor id={id} />}
     </HeadingTag>
   )
 }

--- a/src/components/mdx/mdx-table-scroll.tsx
+++ b/src/components/mdx/mdx-table-scroll.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+type MdxTableScrollProps = React.ComponentPropsWithoutRef<"table">
+
+type ScrollState = {
+  hasOverflow: boolean
+  canScrollLeft: boolean
+  canScrollRight: boolean
+}
+
+const initialScrollState: ScrollState = {
+  hasOverflow: false,
+  canScrollLeft: false,
+  canScrollRight: false,
+}
+
+export function MdxTableScroll({ className, ...props }: MdxTableScrollProps) {
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const [scrollState, setScrollState] = React.useState(initialScrollState)
+
+  const updateScrollState = React.useCallback(() => {
+    const container = containerRef.current
+
+    if (!container) {
+      return
+    }
+
+    const hasOverflow = container.scrollWidth > container.clientWidth + 1
+    const canScrollLeft = hasOverflow && container.scrollLeft > 1
+    const canScrollRight =
+      hasOverflow && container.scrollLeft + container.clientWidth < container.scrollWidth - 1
+
+    setScrollState((current) => {
+      if (
+        current.hasOverflow === hasOverflow &&
+        current.canScrollLeft === canScrollLeft &&
+        current.canScrollRight === canScrollRight
+      ) {
+        return current
+      }
+
+      return { hasOverflow, canScrollLeft, canScrollRight }
+    })
+  }, [])
+
+  React.useEffect(() => {
+    const container = containerRef.current
+
+    if (!container) {
+      return undefined
+    }
+
+    updateScrollState()
+
+    const resizeObserver = new ResizeObserver(updateScrollState)
+    resizeObserver.observe(container)
+
+    const table = container.querySelector("table")
+    if (table) {
+      resizeObserver.observe(table)
+    }
+
+    return () => resizeObserver.disconnect()
+  }, [updateScrollState])
+
+  return (
+    <div data-slot="mdx-table-scroll" className="relative min-w-0">
+      <div
+        ref={containerRef}
+        role={scrollState.hasOverflow ? "region" : undefined}
+        aria-label={scrollState.hasOverflow ? "Scrollable table" : undefined}
+        tabIndex={scrollState.hasOverflow ? 0 : undefined}
+        onScroll={updateScrollState}
+        className={cn(
+          "w-full overflow-x-auto",
+          "focus-visible:rounded-sm focus-visible:outline-none",
+          "focus-visible:ring-2 focus-visible:ring-ring/50"
+        )}
+      >
+        <table
+          data-slot="mdx-table"
+          className={cn("w-full caption-bottom text-sm", className)}
+          {...props}
+        />
+      </div>
+
+      <div
+        aria-hidden="true"
+        data-slot="mdx-table-scroll-start"
+        className={cn(
+          "pointer-events-none absolute inset-y-0 left-0 w-8",
+          "bg-linear-to-r from-background to-transparent",
+          "transition-opacity duration-200 motion-reduce:transition-none",
+          scrollState.canScrollLeft ? "opacity-100" : "opacity-0"
+        )}
+      />
+
+      <div
+        aria-hidden="true"
+        data-slot="mdx-table-scroll-end"
+        className={cn(
+          "pointer-events-none absolute inset-y-0 right-0 w-8",
+          "bg-linear-to-l from-background to-transparent",
+          "transition-opacity duration-200 motion-reduce:transition-none",
+          scrollState.canScrollRight ? "opacity-100" : "opacity-0"
+        )}
+      />
+    </div>
+  )
+}

--- a/src/components/mdx/mdx-table.tsx
+++ b/src/components/mdx/mdx-table.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
+import { MdxTableScroll } from "@/components/mdx/mdx-table-scroll"
 import {
-  Table,
   TableBody,
   TableCaption,
   TableCell,
@@ -14,7 +14,7 @@ import { cn } from "@/lib/utils"
 
 export function MdxTable({ className, ...props }: React.ComponentPropsWithoutRef<"table">) {
   return (
-    <Table
+    <MdxTableScroll
       data-slot="mdx-table"
       className={cn("text-sm", "[&_code]:whitespace-nowrap", className)}
       {...props}

--- a/src/components/pages/post/post-meta-info.tsx
+++ b/src/components/pages/post/post-meta-info.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 
+import { PostUpdatedDate } from "@/components/pages/post/post-updated-date"
 import { TextLink, TwemojifyText } from "@/components/ui/my"
 import { type PostMeta } from "@/lib/content"
 import { formatDate, isSameDate } from "@/lib/site/format-date"
@@ -23,6 +24,7 @@ export function PostMetaInfo({
   ...props
 }: PostMetaInfoProps) {
   const shouldShowUpdatedDate = !isSameDate(datePublish, dateUpdate)
+  const formattedUpdatedDate = formatDate(dateUpdate)
 
   return (
     <div
@@ -73,7 +75,7 @@ export function PostMetaInfo({
             ·
           </span>
           <span>
-            Updated <time dateTime={dateUpdate}>{formatDate(dateUpdate)}</time>
+            Updated <PostUpdatedDate value={dateUpdate} formattedValue={formattedUpdatedDate} />
           </span>
         </>
       )}

--- a/src/components/pages/post/post-updated-date.tsx
+++ b/src/components/pages/post/post-updated-date.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import * as React from "react"
+
+const millisecondsPerDay = 24 * 60 * 60 * 1000
+const recentUpdateDayLimit = 30
+
+type PostUpdatedDateProps = {
+  value: string
+  formattedValue: string
+}
+
+export function PostUpdatedDate({ value, formattedValue }: PostUpdatedDateProps) {
+  const getRelativeLabel = React.useCallback(() => {
+    const dayDifference = getDayDifference(value, new Date())
+
+    if (dayDifference > 0 || dayDifference < -recentUpdateDayLimit) {
+      return undefined
+    }
+
+    const locale = document.documentElement.lang || undefined
+    return new Intl.RelativeTimeFormat(locale, { numeric: "auto" }).format(dayDifference, "day")
+  }, [value])
+
+  const relativeLabel = React.useSyncExternalStore(
+    subscribeToDateChanges,
+    getRelativeLabel,
+    getServerRelativeLabel
+  )
+
+  const isRelative = relativeLabel !== undefined
+
+  return (
+    <time
+      dateTime={value}
+      aria-label={formattedValue}
+      title={isRelative ? `Updated on ${formattedValue}` : undefined}
+      className={
+        isRelative
+          ? "decoration-dotted underline-offset-4 hover:underline hover:decoration-muted-foreground"
+          : undefined
+      }
+    >
+      {relativeLabel ?? formattedValue}
+    </time>
+  )
+}
+
+function subscribeToDateChanges() {
+  return () => undefined
+}
+
+function getServerRelativeLabel() {
+  return undefined
+}
+
+function getDayDifference(value: string, now: Date): number {
+  const [year, month, day] = value.split("-").map(Number)
+  const targetDate = Date.UTC(year, month - 1, day)
+  const currentDate = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())
+
+  return Math.round((targetDate - currentDate) / millisecondsPerDay)
+}

--- a/src/components/site/back-to-top.tsx
+++ b/src/components/site/back-to-top.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import * as React from "react"
+
+import { IconArrowUp } from "@tabler/icons-react"
+
+import { IconButton } from "@/components/ui/my"
+import { cn } from "@/lib/utils"
+
+function scrollToTop() {
+  const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+
+  window.scrollTo({
+    top: 0,
+    behavior: reduceMotion ? "auto" : "smooth",
+  })
+}
+
+export function BackToTop() {
+  const [isVisible, setIsVisible] = React.useState(false)
+
+  React.useEffect(() => {
+    let frame = 0
+
+    function updateVisibility() {
+      cancelAnimationFrame(frame)
+
+      frame = requestAnimationFrame(() => {
+        setIsVisible(window.scrollY > window.innerHeight)
+      })
+    }
+
+    updateVisibility()
+
+    window.addEventListener("scroll", updateVisibility, { passive: true })
+    window.addEventListener("resize", updateVisibility)
+
+    return () => {
+      cancelAnimationFrame(frame)
+      window.removeEventListener("scroll", updateVisibility)
+      window.removeEventListener("resize", updateVisibility)
+    }
+  }, [])
+
+  return (
+    <IconButton
+      label="Back to top"
+      tooltipSide="left"
+      variant="outline"
+      size="icon"
+      tabIndex={isVisible ? 0 : -1}
+      aria-hidden={!isVisible}
+      onClick={scrollToTop}
+      className={cn(
+        "fixed right-6 bottom-6 z-40 hidden rounded-full",
+        "border-border/80 bg-background/85 shadow-md backdrop-blur-md md:inline-flex lg:right-8 lg:bottom-8",
+        "transition-[opacity,transform] duration-200 motion-reduce:transition-none",
+        isVisible ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-2 opacity-0"
+      )}
+    >
+      <IconArrowUp aria-hidden="true" className="size-5" />
+    </IconButton>
+  )
+}

--- a/src/components/site/back-to-top.tsx
+++ b/src/components/site/back-to-top.tsx
@@ -53,7 +53,8 @@ export function BackToTop() {
       onClick={scrollToTop}
       className={cn(
         "fixed right-6 bottom-6 z-40 hidden rounded-full",
-        "border-border/80 bg-background/85 shadow-md backdrop-blur-md md:inline-flex lg:right-8 lg:bottom-8",
+        "border-border/80 bg-background/85 shadow-md backdrop-blur-md",
+        "lg:right-8 lg:bottom-8 md:[@media(hover:hover)_and_(pointer:fine)]:inline-flex",
         "transition-[opacity,transform] duration-200 motion-reduce:transition-none",
         isVisible ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-2 opacity-0"
       )}

--- a/src/components/site/theme-toggle.tsx
+++ b/src/components/site/theme-toggle.tsx
@@ -1,10 +1,16 @@
 "use client"
 
+import { flushSync } from "react-dom"
+
 import { IconMoon, IconSun } from "@tabler/icons-react"
 import { useTheme } from "@wrksz/themes/client"
 import { useHydrated } from "@wrksz/themes/client/use-hydrated"
 
 import { IconButton } from "@/components/ui/my"
+
+function clearThemeTransitionState() {
+  delete document.documentElement.dataset.themeTransition
+}
 
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme()
@@ -17,13 +23,26 @@ export function ThemeToggle() {
       : "Switch to dark mode"
     : "Toggle color theme"
 
+  function handleClick() {
+    const nextTheme = isDark ? "light" : "dark"
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+
+    if (prefersReducedMotion || typeof document.startViewTransition !== "function") {
+      setTheme(nextTheme)
+      return
+    }
+
+    document.documentElement.dataset.themeTransition = ""
+
+    const transition = document.startViewTransition(() => {
+      flushSync(() => setTheme(nextTheme))
+    })
+
+    void transition.finished.then(clearThemeTransitionState, clearThemeTransitionState)
+  }
+
   return (
-    <IconButton
-      label={label}
-      tooltip={label}
-      disabled={!hydrated}
-      onClick={() => setTheme(isDark ? "light" : "dark")}
-    >
+    <IconButton label={label} tooltip={label} disabled={!hydrated} onClick={handleClick}>
       {hydrated ? (
         isDark ? (
           <IconSun aria-hidden="true" className="size-5" />

--- a/src/styles/mdx-heading.css
+++ b/src/styles/mdx-heading.css
@@ -1,0 +1,27 @@
+/* Briefly identify the section reached through a heading hash link. */
+
+[data-slot="mdx-heading"]:target > [data-slot="mdx-heading-content"] {
+  border-radius: var(--radius-sm);
+  animation: mdx-heading-target 1.5s ease-out;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+@keyframes mdx-heading-target {
+  from {
+    background-color: color-mix(in oklab, var(--primary) 14%, transparent);
+    box-shadow: 0 0 0 0.2rem color-mix(in oklab, var(--primary) 14%, transparent);
+  }
+
+  to {
+    background-color: transparent;
+    box-shadow: 0 0 0 0.2rem transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot="mdx-heading"]:target > [data-slot="mdx-heading-content"] {
+    animation: none;
+    color: var(--primary);
+  }
+}

--- a/src/styles/theme-transition.css
+++ b/src/styles/theme-transition.css
@@ -1,0 +1,21 @@
+/* Cross-fade the new theme over the current page when the browser supports View Transitions. */
+
+html[data-theme-transition]::view-transition-old(root) {
+  animation: none;
+}
+
+html[data-theme-transition]::view-transition-new(root) {
+  animation: theme-fade-in 200ms ease-out;
+}
+
+@keyframes theme-fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-theme-transition]::view-transition-new(root) {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

- add a desktop-only back-to-top control after the reader scrolls beyond one viewport
- make heading anchors copy their canonical section URL, show copy feedback, remain discoverable on touch devices, and briefly identify hash targets
- cross-fade supported theme changes while respecting `prefers-reduced-motion`
- keep the existing code toolbar and add expand/collapse controls for blocks longer than 10 lines
- preserve the existing table overflow behavior while adding edge fades and keyboard-accessible horizontal scrolling
- preserve the existing same-date suppression and show updates from the last 30 days relatively, with the exact date available as a tooltip

## Implementation notes

- Back to Top requires the `md` breakpoint plus hover and a fine pointer, and is removed from the tab order while inactive.
- Theme changes fall back to the existing immediate switch when View Transitions are unavailable or reduced motion is enabled.
- Long code blocks expand automatically for printing.
- Existing heading slugs, ToC behavior, code copy behavior, and table semantics remain unchanged.

## Verification

- production `next build`
- Oxlint
- Oxfmt check