### PR TITLE
feat: fade theme transitions

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,7 @@
 @import "../styles/code-highlight.css";
 @import "../styles/footnote.css";
 @import "../styles/katex.css";
+@import "../styles/theme-transition.css";
 @import "../styles/twemoji.css";
 
 @custom-variant dark (&:is(.dark *));

--- a/src/components/site/theme-toggle.tsx
+++ b/src/components/site/theme-toggle.tsx
@@ -25,8 +25,9 @@ export function ThemeToggle() {
 
   function handleClick() {
     const nextTheme = isDark ? "light" : "dark"
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
 
-    if (typeof document.startViewTransition !== "function") {
+    if (prefersReducedMotion || typeof document.startViewTransition !== "function") {
       setTheme(nextTheme)
       return
     }

--- a/src/components/site/theme-toggle.tsx
+++ b/src/components/site/theme-toggle.tsx
@@ -1,10 +1,16 @@
 "use client"
 
+import { flushSync } from "react-dom"
+
 import { IconMoon, IconSun } from "@tabler/icons-react"
 import { useTheme } from "@wrksz/themes/client"
 import { useHydrated } from "@wrksz/themes/client/use-hydrated"
 
 import { IconButton } from "@/components/ui/my"
+
+function clearThemeTransitionState() {
+  delete document.documentElement.dataset.themeTransition
+}
 
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme()
@@ -17,13 +23,25 @@ export function ThemeToggle() {
       : "Switch to dark mode"
     : "Toggle color theme"
 
+  function handleClick() {
+    const nextTheme = isDark ? "light" : "dark"
+
+    if (typeof document.startViewTransition !== "function") {
+      setTheme(nextTheme)
+      return
+    }
+
+    document.documentElement.dataset.themeTransition = ""
+
+    const transition = document.startViewTransition(() => {
+      flushSync(() => setTheme(nextTheme))
+    })
+
+    void transition.finished.then(clearThemeTransitionState, clearThemeTransitionState)
+  }
+
   return (
-    <IconButton
-      label={label}
-      tooltip={label}
-      disabled={!hydrated}
-      onClick={() => setTheme(isDark ? "light" : "dark")}
-    >
+    <IconButton label={label} tooltip={label} disabled={!hydrated} onClick={handleClick}>
       {hydrated ? (
         isDark ? (
           <IconSun aria-hidden="true" className="size-5" />

--- a/src/styles/theme-transition.css
+++ b/src/styles/theme-transition.css
@@ -1,0 +1,22 @@
+/*
+ * Keep the current page visible and fade the new theme over it.
+ * The data attribute limits this animation to theme changes.
+ */
+
+html[data-theme-transition]::view-transition-old(root) {
+  animation: none;
+}
+
+html[data-theme-transition]::view-transition-new(root) {
+  animation: theme-fade-in 200ms ease-out both;
+}
+
+@keyframes theme-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary

- fade the new color theme over the current page with the View Transition API
- switch immediately when View Transitions are unavailable or the user prefers reduced motion
- scope the animation to theme changes while retaining `disableTransitionOnChange` so element-level CSS transitions do not compete with the page fade

## Scope

This PR only changes the Theme Toggle transition:

- `src/components/site/theme-toggle.tsx`
- `src/styles/theme-transition.css`
- `src/app/globals.css`

No other animated components are changed.

## Verification

- reviewed the commit diff against the latest `main`
- confirmed the PR contains only the three files above