### PR TITLE
feat: add MDX image viewer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "react-dom": "19.2.8",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0",
+        "yet-another-react-lightbox-lite": "^2.1.2",
       },
       "devDependencies": {
         "@content-collections/core": "^0.15.2",
@@ -1521,6 +1522,8 @@
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yet-another-react-lightbox-lite": ["yet-another-react-lightbox-lite@2.1.2", "", { "peerDependencies": { "@types/react": "^18 || ^19", "@types/react-dom": "^18 || ^19", "react": "^18 || ^19", "react-dom": "^18 || ^19" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-3MaTCzUlVqLp1Bt/qUcxsTcXbYrsdf1Rd8FgvI4oOgCCD8TODyELwzqtf++R8EyhCHMsZN/eLGh6B3Ui12HV9w=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "tailwind-merge": "^3.6.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "yet-another-react-lightbox-lite": "^2.1.2"
   },
   "devDependencies": {
     "@content-collections/core": "^0.15.2",

--- a/src/components/mdx/mdx-image-viewer.tsx
+++ b/src/components/mdx/mdx-image-viewer.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import * as React from "react"
+
+import { IconZoomIn, IconZoomOut } from "@tabler/icons-react"
+import Lightbox, {
+  IconButton as LightboxIconButton,
+  type SlideImage,
+  useZoom,
+} from "yet-another-react-lightbox-lite"
+
+import { cn } from "@/lib/utils"
+
+import "yet-another-react-lightbox-lite/styles.css"
+
+const triggerSelector = "img[data-mdx-image-viewer-trigger]"
+
+type MdxImageViewerProps = React.ComponentPropsWithoutRef<"div">
+
+type PreservedAttributes = {
+  image: HTMLImageElement
+  ariaHasPopup: string | null
+  ariaLabel: string | null
+  role: string | null
+  tabIndex: string | null
+}
+
+function isViewableImage(image: HTMLImageElement): boolean {
+  return (
+    Boolean(image.alt.trim()) &&
+    image.getAttribute("aria-hidden") !== "true" &&
+    image.getAttribute("role") !== "presentation" &&
+    !image.matches(".twemoji, [data-twemoji]") &&
+    !image.closest("a, button, [role='button']")
+  )
+}
+
+function restoreAttribute(element: Element, name: string, value: string | null) {
+  if (value === null) {
+    element.removeAttribute(name)
+  } else {
+    element.setAttribute(name, value)
+  }
+}
+
+function getTriggerImage(target: EventTarget | null): HTMLImageElement | undefined {
+  return target instanceof Element
+    ? (target.closest<HTMLImageElement>(triggerSelector) ?? undefined)
+    : undefined
+}
+
+function getImageSlide(image: HTMLImageElement): SlideImage {
+  const width = Number(image.getAttribute("width")) || image.naturalWidth || undefined
+  const height = Number(image.getAttribute("height")) || image.naturalHeight || undefined
+
+  return {
+    src: image.dataset.mdxImageSrc || image.currentSrc || image.src,
+    alt: image.alt,
+    width,
+    height,
+  }
+}
+
+function ZoomButtons() {
+  const { zoom, maxZoom, changeZoom } = useZoom()
+
+  return (
+    <>
+      <LightboxIconButton
+        label="Zoom out"
+        icon={IconZoomOut}
+        disabled={zoom <= 1}
+        onClick={() => changeZoom(Math.max(1, zoom / 2))}
+      />
+      <LightboxIconButton
+        label="Zoom in"
+        icon={IconZoomIn}
+        disabled={zoom >= maxZoom}
+        onClick={() => changeZoom(Math.min(maxZoom, zoom * 2))}
+      />
+    </>
+  )
+}
+
+export function MdxImageViewer({ className, children, ...props }: MdxImageViewerProps) {
+  const rootRef = React.useRef<HTMLDivElement>(null)
+  const [slide, setSlide] = React.useState<SlideImage>()
+
+  React.useEffect(() => {
+    const root = rootRef.current
+
+    if (!root || children === undefined) {
+      return undefined
+    }
+
+    const viewerRoot: HTMLDivElement = root
+    const images = Array.from(viewerRoot.querySelectorAll("img"))
+      .filter(isViewableImage)
+      .map((image): PreservedAttributes => ({
+        image,
+        ariaHasPopup: image.getAttribute("aria-haspopup"),
+        ariaLabel: image.getAttribute("aria-label"),
+        role: image.getAttribute("role"),
+        tabIndex: image.getAttribute("tabindex"),
+      }))
+
+    for (const { image } of images) {
+      image.dataset.mdxImageViewerTrigger = ""
+      image.setAttribute("aria-haspopup", "dialog")
+      image.setAttribute("aria-label", `View image: ${image.alt}`)
+      image.setAttribute("role", "button")
+      image.tabIndex = 0
+    }
+
+    function openImage(image: HTMLImageElement) {
+      if (viewerRoot.contains(image)) {
+        setSlide(getImageSlide(image))
+      }
+    }
+
+    function handleClick(event: MouseEvent) {
+      const image = getTriggerImage(event.target)
+
+      if (image) {
+        openImage(image)
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Enter" && event.key !== " ") {
+        return
+      }
+
+      const image = getTriggerImage(event.target)
+
+      if (image) {
+        event.preventDefault()
+        openImage(image)
+      }
+    }
+
+    viewerRoot.addEventListener("click", handleClick)
+    viewerRoot.addEventListener("keydown", handleKeyDown)
+
+    return () => {
+      viewerRoot.removeEventListener("click", handleClick)
+      viewerRoot.removeEventListener("keydown", handleKeyDown)
+
+      for (const { image, ariaHasPopup, ariaLabel, role, tabIndex } of images) {
+        delete image.dataset.mdxImageViewerTrigger
+        restoreAttribute(image, "aria-haspopup", ariaHasPopup)
+        restoreAttribute(image, "aria-label", ariaLabel)
+        restoreAttribute(image, "role", role)
+        restoreAttribute(image, "tabindex", tabIndex)
+      }
+    }
+  }, [children])
+
+  return (
+    <>
+      <div
+        ref={rootRef}
+        className={cn(
+          "[&_img[data-mdx-image-viewer-trigger]]:cursor-zoom-in",
+          "[&_img[data-mdx-image-viewer-trigger]]:transition-opacity",
+          "[&_img[data-mdx-image-viewer-trigger]]:duration-200",
+          "[&_img[data-mdx-image-viewer-trigger]]:outline-none",
+          "[&_img[data-mdx-image-viewer-trigger]:hover]:opacity-95",
+          "[&_img[data-mdx-image-viewer-trigger]:focus-visible]:ring-3",
+          "[&_img[data-mdx-image-viewer-trigger]:focus-visible]:ring-ring/50",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+
+      <Lightbox
+        slides={slide ? [slide] : []}
+        index={slide ? 0 : undefined}
+        setIndex={(nextIndex) => {
+          if (nextIndex === undefined) {
+            setSlide(undefined)
+          }
+        }}
+        toolbar={{ buttons: [<ZoomButtons key="zoom" />] }}
+        carousel={{ preload: 0 }}
+        zoom={{ maxZoom: 4 }}
+        slots={{
+          portal: {
+            style: {
+              "--yarll__backdrop_color": "oklch(0.12 0.01 286 / 0.96)",
+              "--yarll__button_background_color": "rgb(255 255 255 / 0.1)",
+              "--yarll__button_color": "rgb(255 255 255 / 0.8)",
+              "--yarll__button_color_active": "white",
+              "--yarll__button_filter": "none",
+              "--yarll__button_focus_box_shadow": "0 0 0 3px rgb(255 255 255 / 0.5)",
+              "--yarll__button_focus_outline": "none",
+              "--yarll__fade_duration": "200ms",
+              "--yarll__icon_size": "24px",
+              "--yarll__portal_zindex": 60,
+              "--yarll__toolbar_margin": "16px",
+            },
+          },
+          button: {
+            className: "rounded-md transition-colors hover:bg-white/20",
+          },
+          image: {
+            className: "rounded-lg shadow-2xl",
+          },
+        }}
+      />
+    </>
+  )
+}

--- a/src/components/mdx/mdx-image-viewer.tsx
+++ b/src/components/mdx/mdx-image-viewer.tsx
@@ -17,6 +17,10 @@ const triggerSelector = "img[data-mdx-image-viewer-trigger]"
 
 type MdxImageViewerProps = React.ComponentPropsWithoutRef<"div">
 
+type MdxImageSlide = SlideImage & {
+  caption?: string
+}
+
 type PreservedAttributes = {
   image: HTMLImageElement
   ariaHasPopup: string | null
@@ -49,7 +53,25 @@ function getTriggerImage(target: EventTarget | null): HTMLImageElement | undefin
     : undefined
 }
 
-function getImageSlide(image: HTMLImageElement): SlideImage {
+function getImageCaption(image: HTMLImageElement): string | undefined {
+  let figure = image.closest("figure")
+
+  while (figure) {
+    const caption = Array.from(figure.children).find(
+      (child) => child.tagName === "FIGCAPTION"
+    )?.textContent
+
+    if (caption?.trim()) {
+      return caption.replace(/\s+/g, " ").trim()
+    }
+
+    figure = figure.parentElement?.closest("figure") ?? null
+  }
+
+  return undefined
+}
+
+function getImageSlide(image: HTMLImageElement): MdxImageSlide {
   const width = Number(image.getAttribute("width")) || image.naturalWidth || undefined
   const height = Number(image.getAttribute("height")) || image.naturalHeight || undefined
 
@@ -58,6 +80,7 @@ function getImageSlide(image: HTMLImageElement): SlideImage {
     alt: image.alt,
     width,
     height,
+    caption: getImageCaption(image),
   }
 }
 
@@ -84,7 +107,7 @@ function ZoomButtons() {
 
 export function MdxImageViewer({ className, children, ...props }: MdxImageViewerProps) {
   const rootRef = React.useRef<HTMLDivElement>(null)
-  const [slide, setSlide] = React.useState<SlideImage>()
+  const [slide, setSlide] = React.useState<MdxImageSlide>()
 
   React.useEffect(() => {
     const root = rootRef.current
@@ -183,9 +206,23 @@ export function MdxImageViewer({ className, children, ...props }: MdxImageViewer
             setSlide(undefined)
           }
         }}
-        toolbar={{ buttons: [<ZoomButtons key="zoom" />] }}
+        toolbar={{ fixed: true, buttons: [<ZoomButtons key="zoom" />] }}
         carousel={{ preload: 0 }}
         zoom={{ maxZoom: 4 }}
+        render={{
+          slideFooter: ({ slide: currentSlide }) => {
+            const caption =
+              "caption" in currentSlide && typeof currentSlide.caption === "string"
+                ? currentSlide.caption
+                : undefined
+
+            return caption ? (
+              <div className="yarll__interactive mt-4 max-w-3xl px-4 text-center text-sm leading-6 text-white/70">
+                {caption}
+              </div>
+            ) : null
+          },
+        }}
         slots={{
           portal: {
             style: {
@@ -203,11 +240,17 @@ export function MdxImageViewer({ className, children, ...props }: MdxImageViewer
             },
           },
           button: {
-            className: "rounded-md transition-colors hover:bg-white/20",
+            className: "rounded-md transition-colors hover:bg-white/20 [&_.tabler-icon]:fill-none",
           },
-          image: {
+          image: (currentSlide) => ({
             className: "rounded-lg shadow-2xl",
-          },
+            style: {
+              width: "auto",
+              height: "auto",
+              maxWidth: currentSlide.width ? `min(100%, ${currentSlide.width}px)` : "100%",
+              maxHeight: currentSlide.height ? `min(100%, ${currentSlide.height}px)` : "100%",
+            },
+          }),
         }}
       />
     </>

--- a/src/components/mdx/mdx-image.tsx
+++ b/src/components/mdx/mdx-image.tsx
@@ -93,6 +93,7 @@ export function MdxImage({
         height={parsedHeight}
         sizes={sizes}
         data-slot="mdx-image"
+        data-mdx-image-src={src}
         className={cn(
           "h-auto max-w-3xl rounded-lg border bg-muted/20 object-contain shadow-xs",
           className

--- a/src/components/mdx/mdx-prose.tsx
+++ b/src/components/mdx/mdx-prose.tsx
@@ -8,6 +8,7 @@ import { MdxBlockquote } from "@/components/mdx/mdx-blockquote"
 import { MdxCode, MdxCodeBlock } from "@/components/mdx/mdx-code-highlight"
 import { MdxH1, MdxH2, MdxH3, MdxH4, MdxH5, MdxH6 } from "@/components/mdx/mdx-heading"
 import { MdxImage } from "@/components/mdx/mdx-image"
+import { MdxImageViewer } from "@/components/mdx/mdx-image-viewer"
 import { MdxLink } from "@/components/mdx/mdx-link"
 import { MdxInput, MdxListItem, MdxOrderedList, MdxUnorderedList } from "@/components/mdx/mdx-list"
 import {
@@ -72,7 +73,7 @@ type MdxProseProps = Omit<
 
 export function MdxProse({ code, className, ...props }: MdxProseProps) {
   return (
-    <div
+    <MdxImageViewer
       {...props}
       data-slot="mdx-prose"
       className={cn(
@@ -94,6 +95,6 @@ export function MdxProse({ code, className, ...props }: MdxProseProps) {
       )}
     >
       <MDXContent code={code} components={mdxComponents} />
-    </div>
+    </MdxImageViewer>
   )
 }


### PR DESCRIPTION
## Summary

- add a single-image lightbox to images rendered inside `MdxProse`
- support click, keyboard activation, zoom, pan, Escape/backdrop close, focus restoration, reduced motion, and body scroll locking
- keep the toolbar clear of the image, avoid upscaling images at the initial zoom level, and show MDX captions in the viewer
- preserve the existing `next/image` rendering and captions in the article
- skip linked images, decorative images, Twemoji, and images already inside an interactive element

The viewer is intentionally limited to user-authored MDX. It does not affect covers, avatars, homepage/UI images, or other image components, and it does not add gallery navigation, thumbnails, rotation, download, share, or configuration options.

The implementation uses `yet-another-react-lightbox-lite`, a React 19-compatible, zero-runtime-dependency package focused on the required viewer interactions.

## Verification

- `bun check`
- `bunx tsc --noEmit`
- `SITE_DIR=sites/demo bun run build` (47 static pages)
- verified the generated image fixture keeps original image sources and the existing linked/decorative cases used by the runtime eligibility filter

Closes #25