### PR TITLE
fix: point default Tags navigation to tag archive

### DIFF
--- a/src/lib/config/site-schema.ts
+++ b/src/lib/config/site-schema.ts
@@ -40,7 +40,7 @@ const siteHeaderSchema = z.object({
   nav: z.array(z.object({ label: mz.nonEmptyString(), href: mz.href() })).default([
     { label: "Home", href: "/" },
     { label: "Articles", href: "/posts" },
-    { label: "Tags", href: "/posts" },
+    { label: "Tags", href: "/posts/tags" },
     // { label: "News", href: "/news" },
     // { label: "People", href: "/people" },
     // { label: "About", href: "/about" },


### PR DESCRIPTION
## Summary

- point the default `Tags` navigation item to `/posts/tags`

This affects only sites that rely on the starter's default header navigation.